### PR TITLE
v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3
+
+- Fix ChartJS build in release mode, since AMDJS is in mimic mode.
+- change SDK requirement from 2.8+ to 2.7+. 
+
 ## 1.0.2
 
 - Add support to Bar Charts and Horizontal Bar Charts.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ NOTE: You don't need to read any specific documentation of any engine to use `ch
 since any Chart configuration needed to generate your Chart will be
 automatically handled by this package (see the [examples][example]).
 
+
+## Install
+
+```yaml
+dependencies:
+  chart_engine: ^1.0.3
+```
+
 ## Usage
 
 A simple example using ApexCharts (ChartsJS is commented):
@@ -41,7 +49,7 @@ void main() async {
   //var charEngine = ChartEngineChartJS() ;
   var charEngine = ChartEngineApexCharts() ;
   await charEngine.load() ;
-  charEngine.renderLineChart( querySelector('#chart-output') , series ) ;
+  charEngine.renderLineChart( querySelector('#output') , series ) ;
 
 
 }

--- a/lib/chartjs-2.9.3/chart_engine_wrapper.js
+++ b/lib/chartjs-2.9.3/chart_engine_wrapper.js
@@ -2,7 +2,7 @@
 (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('chartjs') ) :
         typeof define === 'function' && define.amd ? define(['exports', 'chartjs'], factory) :
-            (global = global || self, factory(global.__ChartEngine_Wrapper_ChartJS__ = {}, global.chartjs ));
+            (global = global || self, factory(global.__ChartEngine_Wrapper_ChartJS__ = {}, global.Chart ));
 }(this, (function (exports, Chart)
 { 'use strict';
 

--- a/lib/src/chart_engine_chartjs.dart
+++ b/lib/src/chart_engine_chartjs.dart
@@ -51,7 +51,7 @@ class ChartEngineChartJS extends ChartEngine {
   Future<bool> load() {
     return _loadController.load(() async {
       var jsFullPath = minified ? JS_PATH_MIN : JS_PATH;
-      var okJS = await AMDJS.require('chartjs', jsFullPath);
+      var okJS = await AMDJS.require('chartjs', jsFullPath, globalJSVariableName: 'Chart');
       var okWrapper = await AMDJS.require(
           JS_WRAPPER_GLOBAL_NAME, ENGINE_WRAPPER_PATH,
           globalJSVariableName: JS_WRAPPER_GLOBAL_NAME);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: chart_engine
 description: Chart generator with interchangeable chart engines, like ChartJS and ApexCharts.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/Colossus-Services/chart_engine
 
 environment:
-  sdk: '>=2.8.1 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   swiss_knife: ^2.4.0


### PR DESCRIPTION
- Fix ChartJS build in release mode, since AMDJS is in mimic mode.
- change SDK requirement from 2.8+ to 2.7+.